### PR TITLE
Updated Sphinx documentation

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -87,7 +87,7 @@ The custom `sdist` command adds the following steps:
 > [!NOTE]
 > - do not run `python setup.py` that will not build the full package.
 > - the versions of `pycorese` and Java libraries are maintained separately.
-> - `corese-python` version should be the same as `corese-core` it depends on, for simplicity reasons. 
+> - `corese-python` version should be the same as `corese-core` it depends on, for simplicity reasons.
 > -  the commands for the first two steps are provided in the [Obtaining Java libraries manually](#obtain-java-libraries-manually) section.
 
 ## Testing the package
@@ -134,7 +134,7 @@ pip install dist/pycorese-0.1.1.tar.gz
 
 ## Verifying the installation
 
-```
+```bash
 $ pip list  | grep corese
 pycorese                  0.1.1
 
@@ -148,13 +148,13 @@ $ python -c 'import pycorese'
 
 Without installing the package you can run the following command (the default Java bridge is `py4j`):
 
-```
+```bash
 ./examples/simple_query.py -j $PWD/build/libs/corese-python-4.6.0-jar-with-dependencies.jar
 ```
 
 or change the bridge to `jpype`:
 
-```
+```bash
 ./examples/simple_query.py -b jpype -j $PWD/build/libs/corese-core-4.6.0-jar-with-dependencies.jar
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 **pycorese** is a Python package that provides a simple way to integrate the [corese-core](https://github.com/corese-stack/corese-core) Java library into Python applications.
 
-**pycorese** provides an intuitive API to interact with Corese's capabilities such as storage, SPARQL engine, RDFS and OWL reasoning, and SHACL validation.
+**pycorese** offers an intuitive API to interact with Corese's capabilities such as storage, SPARQL engine, RDFS and OWL reasoning, and SHACL validation.
 
 **pycorese** unlocks the potential of Semantic Web stack for applications such as semantic data analysis, knowledge graph construction, and Machine Learning.
 

--- a/docs/source/.gitignore
+++ b/docs/source/.gitignore
@@ -1,0 +1,2 @@
+user_guide.ipynb
+dev_install.md

--- a/docs/source/apis.rst
+++ b/docs/source/apis.rst
@@ -1,17 +1,18 @@
-CORESE APIs
+.. The links for corese-command and corese-server are not available in the corese-stack at the moment.
+.. Using the old repository documentation at https://wimmics.github.io/corese.
+
+Corese APIs
 ###########
 
 .. toctree::
   :hidden:
-
-   Python API
 
 .. grid:: 2
 
     .. grid-item-card::
       :shadow: sm
       :class-card: sd-rounded-3
-      :link: https://corese-stack.github.io/corese-core/
+      :link: https://corese-stack.github.io/corese-core/v4.6.0/java_api/library_root.html
 
       Corese Java API
       ^^^^^^^^^^^^^^^^^^^^^^^
@@ -31,7 +32,7 @@ CORESE APIs
     .. grid-item-card::
       :shadow: sm
       :class-card: sd-rounded-3
-      :link: https://corese-stack.github.io/corese-command/
+      :link: https://wimmics.github.io/corese/cli_ref/cli_root.html
 
       Corese command-line interface
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -47,7 +48,7 @@ CORESE APIs
     .. grid-item-card::
       :shadow: sm
       :class-card: sd-rounded-3
-      :link: https://github.com/corese-stack/corese-server/
+      :link: https://wimmics.github.io/corese/rest_api/api_root.html
 
       Corese REST API
       ^^^^^^^^^^^^^^^^^^^^^^^
@@ -62,7 +63,7 @@ CORESE APIs
     .. grid-item-card::
       :shadow: sm
       :class-card: sd-rounded-3
-      :link: https://github.com/corese-stack/corese-python/
+      :link: python_api/api_root.html
 
       Corese Python API
       ^^^^^^^^^^^^^^^^^^^^^^^
@@ -73,4 +74,4 @@ CORESE APIs
       * run SPARQL queries (SELECT, CONSTRUCT, ASK, UPDATE)
       * validate RDF data against SHACL shapes
 
-            in development...
+      and more...

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -10,56 +10,48 @@
 # add these directories to sys.path here.
 import pathlib
 import sys
-import os
+import shutil
 
-sys.path.insert(0, pathlib.Path(__file__).parents[1].resolve().as_posix())
-sys.path.insert(0, pathlib.Path(__file__).parents[2].resolve().as_posix())
-#sys.path.insert(0, pathlib.Path(__file__).parents[2].joinpath('code').resolve().as_posix())
+# -- Path to the Python source code ------------------------------------------------
+sys.path.insert(0, pathlib.Path(__file__).parents[2].joinpath('src').resolve().as_posix())
 
+# -- Copy files for docs --------------------------------------------------
+#
+# To avoid duplicating the information and symlinks
+shutil.copyfile(pathlib.Path(__file__).parents[2].joinpath('INSTALL.md'), "dev_install.md")
+shutil.copyfile(pathlib.Path(__file__).parents[2].joinpath('examples/example1.ipynb'), "user_guide.ipynb")
 
-project = 'CORESE-PYTHON'
+# -- Project information -----------------------------------------------------
+project = 'corese-python'
 copyright = '2024, WIMMICS'
-author = 'WIMMICS'
-
-# -- General configuration ---------------------------------------------------
-# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
-
-extensions = [
-    'sphinx.ext.duration', # to display the duration of Sphinx processing
-    'sphinx.ext.todo', # to include todo items in the documentation
-    # Uncomment the following lines if/when include the python code (not used in this project yet)
-    #'sphinx.ext.doctest', # to test code snippets in the documentation
-    #'sphinx.ext.autodoc', # to automatically generate documentation from docstrings
-    #'sphinx.ext.autosummary', # this extension generates function/method/attribute summary lists
-    #'sphinx.ext.autosectionlabel', # to automatically generate section labels
-    'sphinx_multiversion',
-    'sphinx_design', # to render panels
-    'myst_parser', # to parse markdown
-    'sphinxcontrib.mermaid', # to render mermaid diagrams
-    # Alternative ways to include markdown files, cannot be used together with myst_parser
-    # advantages of sphynx_mdinclude/m2r3: it can include partial markdown files
-    #
-    #'sphinx_mdinclude', # to include partial markdown files
-    #'m2r3', # to include markdown files
-    'sphinx_copybutton', # to add copy buttons to code blocks
-    ]
-
-templates_path = ['_templates']
-exclude_patterns = []
+author = 'Corese Team'
 
 # The suffix(es) of source filenames.
 source_suffix = ['.rst', '.md']
+#exclude_patterns = []
 
-# -- Options for HTML output -------------------------------------------------
-# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
 
-html_theme = 'pydata_sphinx_theme'
+# Add any paths that contain data files here, relative to this directory.
 html_static_path = ['_static']
 
+# Define the css files to include in the documentation
 html_css_files = [
     "css/custom.css",
 ]
+
+# Define the js files to include in the documentation
 html_js_files = []
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+html_sidebars = {
+  #"corese": [], # syntax for hiding the sidebar
+}
+
+# Tell sphinx what the pygments highlight language should be.
+highlight_language = 'python'
 
 # Project logo, to place at the top of the sidebar.
 html_logo = "_static/corese.svg"
@@ -68,13 +60,14 @@ html_logo = "_static/corese.svg"
 html_favicon = "_static/Corese-square-logo-transparent.svg"
 
 # Modify the title to get good social-media links
-html_title = "CORESE-PYTHON"
-html_short_title = "CORESE-PYTHON"
+#html_title = "CORESE-PYTHON"
+#html_short_title = "CORESE-PYTHON"
 
 # -- Theme Options -----------------------------------------------------------
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
-# documentation.
+# documentation. https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+html_theme = 'pydata_sphinx_theme'
 html_theme_options = {
      "logo": {
          "image_relative": "_static/corese.svg",
@@ -93,27 +86,78 @@ html_theme_options = {
     "switcher": {"json_url": "https://corese-stack.github.io/corese-python/switcher.json", "version_match": r"v\d+\.\d+\.\d+"}
 }
 
-html_sidebars = {
-  "install": [],
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+extensions = [
+    'sphinx.ext.duration', # to display the duration of Sphinx processing
+    'sphinx.ext.todo', # to include todo items in the documentation
+    #'sphinx.ext.githubpages', # to deploy the documentation on GitHub pages ???
+    'sphinx.ext.viewcode', # to add links to the source code
+    'sphinx.ext.doctest', # to test code snippets in the documentation
+    'sphinx.ext.autodoc', # to automatically generate documentation from docstrings
+    'sphinx.ext.autosummary', # this extension generates function/method/attribute summary lists
+    'sphinx.ext.autosectionlabel', # to automatically generate section labels
+    'sphinx.ext.napoleon', # to parse Google-style docstrings
+    'sphinx_design', # to render panels
+    #'myst_parser', # to parse markdown
+    "myst_nb", # to parse jupyter notebooks and markdown files
+    #'sphinxcontrib.mermaid', # to render mermaid diagrams
+    # Alternative ways to include markdown files, cannot be used together with myst_parser
+    # advantages of sphynx_mdinclude/m2r3: it can include partial markdown files
+    #
+    #'sphinx_mdinclude', # to include partial markdown files
+    #'m2r3', # to include markdown files
+    'sphinx_copybutton', # to add copy buttons to code blocks
+    'sphinx_multiversion', # to build documentation for multiple versions
+    ]
+
+# -- Options for sphinx.ext.autodoc / sphinx.ext.autosummary-----------------------------
+# generate autosummary even if no references
+#autodoc_default_flags = ["members", "inherited-members"]
+autosummary_generate = True
+
+autodoc_default_options = {
+    #"member-order": "bysource",
+    #"special-members": "__init__",
+    # "undoc-members": True,
+    # "show-inheritance": True,
+    # "template": "_templates/base.rst",  # Path to your template
 }
 
-# -- MySt-parcer extension Options -------------------------------------------
-# https://myst-parser.readthedocs.io/en/latest/
+# -- Options for sphinx.ext.napoleon----------------------------------------
+napoleon_google_docstring = True
+napoleon_numpy_docstring = True
+napoleon_use_admonition_for_notes = True
+napoleon_use_rtype = False
 
-myst_heading_anchors = 4
-myst_fence_as_directive = ["mermaid"]
-
-# Tell sphinx what the primary language being documented is.
-primary_domain = 'python'
-
-# Tell sphinx what the pygments highlight language should be.
-highlight_language = 'python'
-
-# Setup the sphinx.ext.todo extension
-
-# Set to false in the final version
+# -- Setup the sphinx.ext.todo extension ------------------------------------
+# TODO: Set to false in the final version
 todo_include_todos = True
 
+# -- sphinx-multiversion extension configuration -----------------------------------
 # Optional: Exclude certain branches or tags from multi-versioning
 #smv_branch_whitelist = r'develop'  # TODO Build documentation only for feature/retrieve-doc, must be replaced with "main" for production
 smv_tag_whitelist = r'^v\d+\.\d+.*$'  # Only build tags that match version pattern like v1.0
+
+# -- MyST-NB configuration ---------------------------------------------------
+# https://myst-nb.readthedocs.io/en/latest/
+# Take the example notebook as-is, without executing it
+nb_execution_mode = "off"
+
+# Suppress warnings
+suppress_warnings = [
+    "myst.xref_missing",  # Suppress warnings about missing references after fixing the one you can fix
+    "mystnb.unknown_mime_type"  # Suppress warnings about Google Colab button in the notebook
+]
+
+# Substitute the relative path in the markdown file for the GitHub repo root URL
+def preprocess_markdown(app, docname, source):
+    base_url = "https://github.com/corese-stack/corese-python/blob/main/"
+    if docname == "dev_install":  # Replace with the actual document using the Markdown file
+        content = source[0]
+        # Replace relative paths with appropriate links
+        source[0] = content.replace("./" ,  base_url)
+
+def setup(app):
+    app.connect("source-read", preprocess_markdown)

--- a/docs/source/corese.rst
+++ b/docs/source/corese.rst
@@ -1,0 +1,103 @@
+.. CORESE documentation master file, created by
+   sphinx-quickstart on Tue Apr 16 14:51:03 2024.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+
+.. image:: _static/corese.svg
+   :align: center
+   :width: 400px
+
+.. centered:: Software platform for the Semantic Web of Linked Data
+
+Corese is a software platform implementing and extending the standards of the Semantic Web. It allows to create, manipulate, parse, serialize, query, reason and validate RDF data.
+
+
+
+.. Define named hyperlinks for the references of W3C standards
+.. _RDF: https://www.w3.org/RDF/
+.. _RDFS: https://www.w3.org/2001/sw/wiki/RDFS
+.. _SPARQL1.1 Query & Update: https://www.w3.org/2001/sw/wiki/SPARQL
+.. _OWL RL: https://www.w3.org/2005/rules/wiki/OWLRL
+.. _SHACL: https://www.w3.org/TR/shacl/
+
+.. Define named hyperlinks for the references of extensions
+.. _STTL SPARQL: ./_static/extensions/sttl.html
+.. _SPARQL Rule: ./_static/extensions/rule.html
+.. _LDScript: ./_static/extensions/ldscript.html
+
+.. Original location of the extensions documentation
+.. .. _STTL SPARQL: https://files.inria.fr/corese/doc/sttl.html
+.. .. _SPARQL Rule: https://files.inria.fr/corese/doc/rule.html
+.. .. _LDScript: https://files.inria.fr/corese/doc/ldscript.html
+
+
+.. #############################################################################
+.. The statements below are to produce the grid of cards in the home page
+.. grid:: 2
+
+    .. grid-item-card::
+      :shadow: sm
+      :class-card: sd-rounded-3
+
+      Corese implements W3C standards and extensions
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      * W3C standards
+         * `RDF`_
+         * `RDFS`_
+         * `SPARQL1.1 Query & Update`_
+         * `OWL RL`_
+         * `SHACL`_
+      * Extensions
+         * `STTL SPARQL`_
+         * `SPARQL Rule`_
+         * `LDScript`_
+
+    .. grid-item-card::
+      :shadow: sm
+      :class-card: sd-rounded-3
+
+      Corese offers several interfaces
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      * `corese-core <https://github.com/corese-stack/corese-core/>`_: Java library to process RDF data and use Corese features via an API.
+      * `corese-server  <https://github.com/corese-stack/corese-server/>`_: Tool to easily create, configure and manage SPARQL endpoints.
+      * `corese-GUI <https://github.com/corese-stack/corese-gui/>`_: Graphical interface that allows an easy and visual use of Corese features.
+      * `corese-python (beta) <https://github.com/corese-stack/corese-python/>`_: Python wrapper for accessing and manipulating RDF data with Corese features using py4j.
+      * `corese-command (beta)  <https://github.com/corese-stack/corese-command/>`_: Command Line Interface for Corese that allows users to interact with Corese features from the terminal.
+
+.. .. raw:: html
+
+..    <h3>Contributions and discussions</h3>
+
+.. .. _discussion forum: https://github.com/Wimmics/corese/discussions/
+.. .. _issue reports: https://github.com/Wimmics/corese/issues/
+.. .. _pull requests: https://github.com/Wimmics/corese/pulls/
+
+.. For support questions, comments, and any ideas for improvements you’d like to discuss, please use our `discussion forum`_. We welcome everyone to contribute to `issue reports`_, suggest new features, and create `pull requests`_.
+
+
+.. #############################################################################
+.. The statements below are to produce the title of the page in the tab
+   and a menu with the links to the pages of the documentation
+
+.. raw html below is used to hide the title of the page but retain it in the
+   tab title. https://github.com/sphinx-doc/sphinx/issues/8356
+.. raw:: html
+
+    <div style="visibility: hidden;">
+
+About Corese
+====================
+
+.. raw:: html
+
+   </div>
+
+.. toctree::
+   :maxdepth: 2
+
+   Corese APIs <apis>
+   
+..    Install <INSTALL.md>
+..    User Guide <example1.ipynb>
+..    API <python_api/api_root>

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,77 +1,40 @@
-.. CORESE documentation master file, created by
-   sphinx-quickstart on Tue Apr 16 14:51:03 2024.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
-
+.. pycorese documentation master file, created by
+    sphinx-quickstart on Thu Oct 14 2023.
+    You can adapt this file completely to your liking, but it should at least
+    contain the root `toctree` directive.
 
 .. image:: _static/corese.svg
    :align: center
    :width: 400px
 
-.. centered:: Software platform for the Semantic Web of Linked Data
-
-Corese is a software platform implementing and extending the standards of the Semantic Web. It allows to create, manipulate, parse, serialize, query, reason and validate RDF data.
-
-
+.. centered:: Python API for Corese Semantic Web platform
 
 .. Define named hyperlinks for the references of W3C standards
+.. _Corese: corese.html
+.. _corese-core: https://github.com/corese-stack/corese-core
+
 .. _RDF: https://www.w3.org/RDF/
 .. _RDFS: https://www.w3.org/2001/sw/wiki/RDFS
-.. _SPARQL1.1 Query & Update: https://www.w3.org/2001/sw/wiki/SPARQL
+.. _SPARQL: https://www.w3.org/2001/sw/wiki/SPARQL
 .. _OWL RL: https://www.w3.org/2005/rules/wiki/OWLRL
 .. _SHACL: https://www.w3.org/TR/shacl/
 
-.. Define named hyperlinks for the references of extensions
-.. _STTL SPARQL: ./_static/extensions/sttl.html
-.. _SPARQL Rule: ./_static/extensions/rule.html
-.. _LDScript: ./_static/extensions/ldscript.html
+`Corese`_ is a software platform implementing and extending the standards of the Semantic Web. It allows to create, manipulate, parse, serialize, query, reason, and validate RDF data. Corese is based on the W3C standards `RDF`_, `RDFS`_, `OWL RL`_, `SPARQL`_ and `SHACL`_. Corese is implemented as a set of open-source Java libraries.
 
-.. Original location of the extensions documentation
-.. .. _STTL SPARQL: https://files.inria.fr/corese/doc/sttl.html
-.. .. _SPARQL Rule: https://files.inria.fr/corese/doc/rule.html
-.. .. _LDScript: https://files.inria.fr/corese/doc/ldscript.html
+**pycorese** is a Python package that provides a simple way to integrate the `corese-core`_ Java library into Python applications.
 
+**pycorese** offers an intuitive API to interact with Corese's capabilities such as storage, SPARQL engine, RDFS and OWL reasoning, and SHACL validation.
 
-.. #############################################################################
-.. The statements below are to produce the grid of cards in the home page
-.. grid:: 2
-
-    .. grid-item-card::  
-      :shadow: sm
-      :class-card: sd-rounded-3
-
-      Corese implements W3C standards and extensions
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-      * W3C standards
-         * `RDF`_
-         * `RDFS`_
-         * `SPARQL1.1 Query & Update`_
-         * `OWL RL`_
-         * `SHACL`_
-      * Extensions
-         * `STTL SPARQL`_
-         * `SPARQL Rule`_
-         * `LDScript`_
-
-    .. grid-item-card::
-      :shadow: sm
-      :class-card: sd-rounded-3
-   
-      Corese offers several interfaces
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-      * `corese-core <https://github.com/corese-stack/corese-core/>`_: Java library to process RDF data and use Corese features via an API.
-      * `corese-server  <https://github.com/corese-stack/corese-server/>`_: Tool to easily create, configure and manage SPARQL endpoints.
-      * `corese-GUI <https://github.com/corese-stack/corese-gui/>`_: Graphical interface that allows an easy and visual use of Corese features.
-      * `corese-python (beta) <https://github.com/corese-stack/corese-python/>`_: Python wrapper for accessing and manipulating RDF data with Corese features using py4j.
-      * `corese-command (beta)  <https://github.com/corese-stack/corese-command/>`_: Command Line Interface for Corese that allows users to interact with Corese features from the terminal.
+**pycorese** unlocks the potential of Semantic Web stack for applications such as semantic data analysis, knowledge graph construction, and Machine Learning.
 
 .. raw:: html
 
    <h3>Contributions and discussions</h3>
 
-.. _discussion forum: https://github.com/Wimmics/corese/discussions/
-.. _issue reports: https://github.com/Wimmics/corese/issues/
-.. _pull requests: https://github.com/Wimmics/corese/pulls/
+
+.. _discussion forum: https://github.com/corese-stack/corese-python/discussions/
+.. _issue reports: https://github.com/corese-stack/corese-python/issues/
+.. _pull requests: https://github.com/corese-stack/corese-python/pulls/
 
 For support questions, comments, and any ideas for improvements you’d like to discuss, please use our `discussion forum`_. We welcome everyone to contribute to `issue reports`_, suggest new features, and create `pull requests`_.
 
@@ -80,13 +43,13 @@ For support questions, comments, and any ideas for improvements you’d like to 
 .. The statements below are to produce the title of the page in the tab
    and a menu with the links to the pages of the documentation
 
-.. raw html below is used to hide the title of the page but retain it in the 
+.. raw html below is used to hide the title of the page but retain it in the
    tab title. https://github.com/sphinx-doc/sphinx/issues/8356
 .. raw:: html
 
    <div style="visibility: hidden;">
 
-CORESE documentation
+pycorese doc
 ===================================
 
 .. raw:: html
@@ -94,10 +57,10 @@ CORESE documentation
    </div>
 
 .. toctree::
+   :maxdepth: 2
    :hidden:
 
-   Installation <install.md>
-   User Guide <user_guide>
-   API Reference <apis>
-   Demo <https://corese.inria.fr/>
-
+   User Guide <user_guide.ipynb>
+   API <python_api/index.rst>
+   Install <dev_install.md>
+   About Corese <corese.rst>

--- a/docs/source/python_api/bridges.rst
+++ b/docs/source/python_api/bridges.rst
@@ -1,0 +1,54 @@
+Java bridge packages
+====================
+
+Corese is a stack of Java libraries that implement the standards of the Semantic Web.
+To run and access Java libraries we tested two off-the-shelf packages:
+
+- `py4j <https://www.py4j.org/>`_ - this package establishes a bridge between Python and Java using sockets (IPC). The
+**corese-python** Java library implements the listener and wrapper for ``corese-core`` library and is built with ``gradle`` specifically for **pycorese**.
+
+- `jpype <https://jpype.readthedocs.io/en/latest/>`_ - this package utilizes a single shared memory space by embedding the JVM directly into the Python process. The actual ``corese-core`` Java library is downloaded from the Maven repository.
+
+At first we tried both packages to decide which one is better for our purposes. We found that both `py4j` and `jpype` have their pros and cons. See the comparison table below:
+
+.. list-table:: Compare Python- Java bridge packages
+  :widths: 24 38 38
+  :header-rows: 1
+
+  * -
+    - JPype
+    - Py4J
+
+  * - Core Technology
+    - JNI (direct JVM embedding)
+    - Reflection & Socket IPC
+
+  * - Communication
+    - Shared memory (in-process)
+    - Socket based (out-of-process)
+
+  * - Performance
+    - High (no serialization)
+    - Moderate (due to IPC overhead)
+
+  * - Setup
+    - Requires JVM in-process
+    - *Requires a GatewayServer*
+
+  * - Use case
+    - High-performance scenarios
+    - Lightweight, flexible usage
+
+  * - Crash Tolearnce
+    - *Low: JVM crash affects Python (shared process) and cannot be restarted on its own*
+    - High: JVM and Python are separate processes, so a JVM crash won't take down Python.
+
+  * - Distribution
+    - Download ``corese-core-{version}.jar``
+    - Build ``corese-python-{version}.jar``
+
+Although ``jpype`` is more performant and does not require an extra wrapper library, we decided to use ``py4j`` as a default because it is more crash tolerant. The main reason is that ``jpype`` requires the JVM to be embedded in the Python process and prohibits the restart of this subprocess in case of a crash (by design). This could be a critical issue for long-running applications or services.
+
+However we decided to leave both bridges in the package and let the user choose the one that fits their needs better.
+
+Both Java Libraries are installed with the package and can be used interchangeably. See the `User Guide <../user_guide.html>`_.

--- a/docs/source/python_api/index.rst
+++ b/docs/source/python_api/index.rst
@@ -1,0 +1,86 @@
+.. .. currentmodule:: pycorese
+
+
+Python API Reference
+===================================
+
+**pycorese** is a Python wrapper for accessing and manipulating RDF data with Corese features connected by one of the java bridge packages: ``py4j`` or ``jpype``.
+
+.. note::
+
+    **pycorese** is still in beta version and is under active development. The API may change in future releases.
+
+
+In the following sections, you will find the documentation of the Python API of **pycorese**.
+
+High-level API
+--------------
+
+HIgh-level API is a set of convenience methods to facilitate the common tasks of working with Knowledge Graphs.
+
+.. automodule:: pycorese.api
+   :members:  CoreseAPI
+   :undoc-members:
+
+
+.. contents::
+   :local:
+   :depth: 2
+
+Low-level API
+-------------
+
+Low-level API is a subset of ``corese-core`` classes exposed as Python objects. These are dynamically created classes
+and can be accessed only after the Corese engine is loaded
+
+For the details of these classes and their methods, please refer to the `Corese Java documentation <https://corese-stack.github.io/corese-core/v4.6.0/java_api/library_root.html>`_.
+
+.. autoattribute:: pycorese.api.CoreseAPI.Graph
+   :annotation:
+
+   Corese ``fr.inria.corese.core.Graph`` object.
+
+.. autoattribute:: pycorese.api.CoreseAPI.Load
+   :annotation:
+
+   Corese ``fr.inria.corese.core.load.Load`` object.
+
+.. autoattribute:: pycorese.api.CoreseAPI.QueryProcess
+   :annotation:
+
+   Corese ``fr.inria.corese.core.query.QueryProcess`` object.
+
+.. autoattribute:: pycorese.api.CoreseAPI.ResultFormat
+   :annotation:
+
+   Corese ``fr.inria.corese.core.print.ResultFormat`` object.
+
+.. autoattribute:: pycorese.api.CoreseAPI.RuleEngine
+   :annotation:
+
+   Corese ``fr.inria.corese.core.rule.RuleEngine`` object.
+
+.. autoattribute:: pycorese.api.CoreseAPI.Transformer
+   :annotation:
+
+   Corese ``fr.inria.corese.core.transform.Transformer`` object.
+
+.. autoattribute:: pycorese.api.CoreseAPI.Shacl
+   :annotation:
+
+   Corese ``fr.inria.corese.core.shacl.Shacl`` object.
+
+.. autoattribute:: pycorese.api.CoreseAPI.DataManager
+   :annotation:
+
+   Corese ``fr.inria.corese.core.storage.api.dataManager.DataManager`` object.
+
+.. autoattribute:: pycorese.api.CoreseAPI.CoreseGraphDataManager
+   :annotation:
+
+   Corese ``fr.inria.corese.core.storage.CoreseGraphDataManager`` object.
+
+.. toctree::
+   :maxdepth: 2
+
+   About Java bridges <bridges.rst>

--- a/pkg/env/corese-python.yaml
+++ b/pkg/env/corese-python.yaml
@@ -6,6 +6,9 @@ dependencies:
   - python>=3.10
   - pandas
   - py4j
+  - sphinx>=7.1.2
+  - sphinx-multiversion>=0.2.4
+  - sphinx-design==0.5.0
   - pip
   - pip:
        - jpype1
@@ -14,5 +17,7 @@ dependencies:
        - build
        - pytest
        - pytest-cov
-       - sphinx
-       - pydata_sphinx_theme
+       - pydata_sphinx_theme>=0.14.4
+       - sphinx-copybutton>=0.5.0
+       - myst-parser==2.0.0
+       - myst_nb==1.1.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,11 @@ version = { file = "VERSION.txt" }
 name = "pycorese"
 dynamic = ["version"]
 authors = [
+    { name = "Corese Team", email = "corese@inria.fr" },
     { name = "Anna Bobasheva", email = "anna.bobasheva@inria.fr" },
     { name = "Jean-Luc Szpyrka", email = "jean-luc.szpyrka@inria.fr" },
-    { name = "Remi Ceres", email = "remi.ceres@inria.fr"}
+    { name = "Remi Ceres", email = "remi.ceres@inria.fr"},
+    { name = "Erwan Demairy", email = erwan.demairy@inria.fr"},
 ]
 description = "pycorese: Python API for CORESE Semantic Web platform"
 keywords = ["Query Engine", "SPARQL", "SHACL", "RDF",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
     { name = "Anna Bobasheva", email = "anna.bobasheva@inria.fr" },
     { name = "Jean-Luc Szpyrka", email = "jean-luc.szpyrka@inria.fr" },
     { name = "Remi Ceres", email = "remi.ceres@inria.fr"},
-    { name = "Erwan Demairy", email = erwan.demairy@inria.fr"},
+    { name = "Erwan Demairy", email = "erwan.demairy@inria.fr"},
 ]
 description = "pycorese: Python API for CORESE Semantic Web platform"
 keywords = ["Query Engine", "SPARQL", "SHACL", "RDF",

--- a/src/pycorese/py4J_bridge.py
+++ b/src/pycorese/py4J_bridge.py
@@ -68,7 +68,7 @@ class Py4JBridge:
             pass
 
         if version is None:
-            loggingWarning(f"Py4j: the CORESE library is too old. coreseVersion() is available since 4.6.0 only.")
+            logging.Warning(f"Py4j: the CORESE library is too old. coreseVersion() is available since 4.6.0 only.")
 
         return version
 


### PR DESCRIPTION
New Index.rst page,
Old index.rst page became corese.rst.
Added new pages: python_api/api_root.rst with autogenerated API doc. 
Added python_api/bridges.rst page.
The example1.ipynb notebook is rendered as a uset_guide.html. 
INSTALL.md is rendered as an installation page dev_install.html.